### PR TITLE
haskell-src-exts 1.16.0 support

### DIFF
--- a/Test/Framework/TH/Prime/Parser.hs
+++ b/Test/Framework/TH/Prime/Parser.hs
@@ -91,12 +91,17 @@ isFunBind (FunBind _) = True
 isFunBind _           = False
 
 isPatBind :: Decl -> Bool
-isPatBind (PatBind _ _ _ _ _) = True
+isPatBind PatBind{} = True
 isPatBind _                   = False
 
 fromPatBind :: Decl -> String
+#if MIN_VERSION_haskell_src_exts(1, 16, 0)
+fromPatBind (PatBind _ (PVar (Ident  name)) _ _) = name
+fromPatBind (PatBind _ (PVar (Symbol name)) _ _) = name
+#else
 fromPatBind (PatBind _ (PVar (Ident  name)) _ _ _) = name
 fromPatBind (PatBind _ (PVar (Symbol name)) _ _ _) = name
+#endif
 fromPatBind _ = error "fromPatBind"
 
 fromFunBind :: Decl -> String


### PR DESCRIPTION
I've got an error while trying to build this package with haskell-src-exts-1.16.0.

```
Building test-framework-th-prime-0.0.5...
Preprocessing library test-framework-th-prime-0.0.5...
[1 of 2] Compiling Test.Framework.TH.Prime.Parser ( Test/Framework/TH/Prime/Parser.hs, dist/dist-sandbox-a76a6966/build/Test/Framework/TH/Prime/Parser.o )

Test/Framework/TH/Prime/Parser.hs:98:14:
    Constructor `PatBind' should have 4 arguments, but has been given 5
    In the pattern: PatBind _ (PVar (Ident name)) _ _ _
    In an equation for `fromPatBind':
        fromPatBind (PatBind _ (PVar (Ident name)) _ _ _) = name
Failed to install test-framework-th-prime-0.0.5
```
