### PR TITLE
Update parser to haskell-src-exts-1.18 API changes

### DIFF
--- a/Test/Framework/TH/Prime/Parser.hs
+++ b/Test/Framework/TH/Prime/Parser.hs
@@ -8,9 +8,21 @@ import Control.Applicative
 import Data.List
 import Language.Haskell.Exts.Extension
 import Language.Haskell.Exts.Parser
+#if MIN_VERSION_haskell_src_exts(1, 18, 0)
+import Language.Haskell.Exts.SrcLoc
+#endif
 import Language.Haskell.Exts.Syntax hiding (VarName, Exp)
 import Language.Haskell.TH hiding (Match, Extension (..))
 import Language.Preprocessor.Cpphs hiding (Ident)
+
+#if MIN_VERSION_haskell_src_exts(1, 18, 0)
+-- location field for haskell-src-exts-1.18
+#define L SrcSpanInfo
+#define loc _
+#else
+#define L
+#define loc
+#endif
 
 ----------------------------------------------------------------
 
@@ -43,7 +55,11 @@ toTest tag nm = AppE (AppE (symbol tag ) (string nm)) (symbol nm)
 
 getTests :: FilePath -> IO ([String], [String])
 getTests file = do
+#if MIN_VERSION_haskell_src_exts(1, 18, 0)
+    ParseOk (Module _ _ _ _ decls) <- parseTest file
+#else
     ParseOk (Module _ _ _ _ _ _ decls) <- parseTest file
+#endif
     let funs = map fromFunBind $ filter isFunBind decls
         pats = map fromPatBind $ filter isPatBind decls
         names = funs ++ pats
@@ -52,7 +68,7 @@ getTests file = do
     isProp = ("prop_" `isPrefixOf`)
     isCase = ("case_" `isPrefixOf`)
 
-parseTest :: FilePath -> IO (ParseResult Module)
+parseTest :: FilePath -> IO (ParseResult (Module L))
 parseTest file = do
     raw <- readFile file
     parseModuleWithMode (opt raw) . pack <$> go raw
@@ -72,8 +88,8 @@ parseTest file = do
 #else
         toExtention = read . toStr
 #endif
-        toStr (Ident str) = str
-        toStr (Symbol str) = str
+        toStr (Ident loc str) = str
+        toStr (Symbol loc str) = str
     opt raw = defaultParseMode {
 #if MIN_VERSION_haskell_src_exts(1, 14, 0)
         extensions = nub $ EnableExtension TemplateHaskell : exts raw
@@ -86,25 +102,30 @@ parseTest file = do
 
 ----------------------------------------------------------------
 
-isFunBind :: Decl -> Bool
-isFunBind (FunBind _) = True
-isFunBind _           = False
+isFunBind :: Decl L -> Bool
+isFunBind (FunBind loc _) = True
+isFunBind _               = False
 
-isPatBind :: Decl -> Bool
+isPatBind :: Decl L -> Bool
 isPatBind PatBind{} = True
 isPatBind _                   = False
 
-fromPatBind :: Decl -> String
+fromPatBind :: Decl L -> String
 #if MIN_VERSION_haskell_src_exts(1, 16, 0)
-fromPatBind (PatBind _ (PVar (Ident  name)) _ _) = name
-fromPatBind (PatBind _ (PVar (Symbol name)) _ _) = name
+fromPatBind (PatBind _ (PVar loc (Ident  loc name)) _ _) = name
+fromPatBind (PatBind _ (PVar loc (Symbol loc name)) _ _) = name
 #else
 fromPatBind (PatBind _ (PVar (Ident  name)) _ _ _) = name
 fromPatBind (PatBind _ (PVar (Symbol name)) _ _ _) = name
 #endif
 fromPatBind _ = error "fromPatBind"
 
-fromFunBind :: Decl -> String
+fromFunBind :: Decl L -> String
+#if MIN_VERSION_haskell_src_exts(1, 18, 0)
+fromFunBind (FunBind _floc (Match _ (Ident  _iloc name) _ _ _:_)) = name
+fromFunBind (FunBind _floc (Match _ (Symbol _sloc name) _ _ _:_)) = name
+#else
 fromFunBind (FunBind (Match _ (Ident  name) _ _ _ _:_)) = name
 fromFunBind (FunBind (Match _ (Symbol name) _ _ _ _:_)) = name
+#endif
 fromFunBind _ = error "fromFunBind"


### PR DESCRIPTION
The main API change is addition of location field in most datatypes.

The fix tries to retain compatibility with previos versions of haskell-src-exts.

Closes: https://github.com/kazu-yamamoto/test-framework-th-prime/issues/7
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>